### PR TITLE
Set up a chutney based Tor network for integration tests on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+before_install:
+  - ./test/scripts/install-tor.sh
+  - source test/scripts/install-chutney.sh
 install:
   - pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 before_install:
   - ./test/scripts/install-tor.sh
+  - export PATH=$PATH:$PWD/tor/src/tools:$PWD/tor/src/or
   - source test/scripts/install-chutney.sh
 install:
   - pip install tox

--- a/docs/onionbalance.rst
+++ b/docs/onionbalance.rst
@@ -13,6 +13,7 @@ Submodules
    onionbalance.log
    onionbalance.manager
    onionbalance.service
+   onionbalance.settings
    onionbalance.util
 
 Module contents

--- a/docs/onionbalance.settings.rst
+++ b/docs/onionbalance.settings.rst
@@ -1,0 +1,7 @@
+onionbalance.settings module
+============================
+
+.. automodule:: onionbalance.settings
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pytest]
+norecursedirs = .tox _build tor chutney

--- a/test/scripts/install-chutney.sh
+++ b/test/scripts/install-chutney.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Script to install Chutney, configure a Tor network and wait for the hidden
+# service system to be available.
+git clone https://github.com/DonnchaC/chutney.git
+cd chutney
+./chutney configure networks/hs
+./chutney start networks/hs
+./chutney status networks/hs
+
+# Retry verify until hidden service subsystem is working
+n=0
+until [ $n -ge 20 ]
+do
+  output=$(./chutney verify networks/hs)
+  # Check if chutney output included 'Transmission: Success'.
+  if [[ $output == *"Transmission: Success"* ]]; then
+    hs_address=$(echo $output | grep -Po "([a-z2-7]{16}.onion:\d{2,5})")
+    client_address=$(echo $output | grep -Po -m 1 "(localhost:\d{2,5})" | head -n1)
+    echo "HS system running with service available at $hs_address"
+    export CHUTNEY_ONION_ADDRESS="$hs_address"
+    export CHUTNEY_CLIENT_PORT="$client_address"
+    break
+  else
+    echo "HS system not running yet. Sleeping 15 seconds"
+    n=$[$n+1]
+    sleep 15
+  fi
+done
+cd ..

--- a/test/scripts/install-tor.sh
+++ b/test/scripts/install-tor.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Script to install Tor
+set -ex
+wget https://www.torproject.org/dist/tor-0.2.7.1-alpha.tar.gz
+tar -xzvf tor-0.2.7.1-alpha.tar.gz
+cd tor-0.2.7.1-alpha && ./configure --disable-asciidoc && make && sudo make install

--- a/test/scripts/install-tor.sh
+++ b/test/scripts/install-tor.sh
@@ -3,4 +3,4 @@
 set -ex
 wget https://www.torproject.org/dist/tor-0.2.7.1-alpha.tar.gz
 tar -xzvf tor-0.2.7.1-alpha.tar.gz
-cd tor-0.2.7.1-alpha && ./configure --disable-asciidoc && make && sudo make install
+cd tor-0.2.7.1-alpha && ./configure --disable-asciidoc && make && make install

--- a/test/scripts/install-tor.sh
+++ b/test/scripts/install-tor.sh
@@ -2,5 +2,5 @@
 # Script to install Tor
 set -ex
 wget https://www.torproject.org/dist/tor-0.2.7.1-alpha.tar.gz
-tar -xzvf tor-0.2.7.1-alpha.tar.gz
-cd tor-0.2.7.1-alpha && ./configure --disable-asciidoc && make && make install
+tar -xzvf tor-0.2.7.1-alpha.tar.gz && mv tor-0.2.7.1-alpha tor
+cd tor && ./configure --disable-asciidoc && make


### PR DESCRIPTION
This branch adds scripts to compile Tor from source and install and start a Chutney based Tor test network. The `install-chutney.sh` script will wait until the hidden service subsystem is functioning correctly before letting Travis-CI continue running the tests.

The running Chutney onion service address is exported as `CHUTNEY_ONION_ADDRESS` which can be read later by the integration tests. The running Tor client IP/Port is exported as `CHUTNEY_CLIENT_PORT` to allow the integration tests to determine the correct client control port for the OnionBalance server.