### PR TITLE
Use packaged Tor and Chutney for the testing enviroment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: required
 env:
   - TOXENV=py27 TEST=functional
   - TOXENV=py34 TEST=functional
@@ -7,7 +8,6 @@ env:
 before_install:
   # Install tor and chutney if doing functional tests
   - if [[ $TEST == 'functional' ]]; then ./test/scripts/install-tor.sh; fi
-  - if [[ $TEST == 'functional' ]]; then export PATH=$PATH:$PWD/tor/src/tools:$PWD/tor/src/or; fi
   - if [[ $TEST == 'functional' ]]; then source test/scripts/install-chutney.sh; fi
 install:
   - pip install tox

--- a/test/scripts/install-chutney.sh
+++ b/test/scripts/install-chutney.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Script to install Chutney, configure a Tor network and wait for the hidden
 # service system to be available.
-git clone https://github.com/DonnchaC/chutney.git
+git clone https://git.torproject.org/chutney.git
 cd chutney
 # Stop chutney network if it is already running
 ./chutney stop networks/hs

--- a/test/scripts/install-tor.sh
+++ b/test/scripts/install-tor.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 # Script to install Tor
 set -ex
-wget https://www.torproject.org/dist/tor-0.2.7.1-alpha.tar.gz
-tar -xzvf tor-0.2.7.1-alpha.tar.gz && mv tor-0.2.7.1-alpha tor
-cd tor && ./configure --disable-asciidoc && make
+echo "deb http://deb.torproject.org/torproject.org precise main" | sudo tee -a /etc/apt/sources.list
+echo "deb-src http://deb.torproject.org/torproject.org precise main" | sudo tee -a /etc/apt/sources.list
+echo "deb http://deb.torproject.org/torproject.org tor-experimental-0.2.7.x-precise main" | sudo tee -a /etc/apt/sources.list
+echo "deb-src http://deb.torproject.org/torproject.org tor-experimental-0.2.7.x-precise main" | sudo tee -a /etc/apt/sources.list
+
+# Install Tor repo signing key
+gpg --keyserver keys.gnupg.net --recv 886DDD89
+gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | sudo apt-key add -
+
+sudo apt-get update -qq
+sudo apt-get install tor deb.torproject.org-keyring


### PR DESCRIPTION
Tor 0.2.7.x is now packaged and available from the Tor Project experimental repository. Using the packaged Tor speeds up the test set-up considerably. 

My Chutney patch to open a control port on the Tor client is merged so we can run Chutney from the upstream repository.