### PR TITLE
Fixed intro point shuffle bug that causes IP selection bias

### DIFF
--- a/onionbalance/descriptor.py
+++ b/onionbalance/descriptor.py
@@ -29,8 +29,10 @@ def choose_introduction_point_set(available_introduction_points):
     Return a list of IntroductionPoints.
     """
 
-    # Shuffle the instance order before beginning to pick intro points
-    random.shuffle(available_introduction_points)
+    # Shuffle intro points order for each instance before beginning
+    # to pick right intro points
+    for ip_group in available_introduction_points:
+        random.shuffle(ip_group)
 
     num_active_instances = len(available_introduction_points)
     ips_per_instance = [len(ips) for ips in available_introduction_points]


### PR DESCRIPTION
We shuffled instance order that is useless.
Because of that we always picked up introduction points from the beginning of an IP set from each instance. Of course this is not uniform balancing because we have some IP not used when number of IPs picked by us is less than available.