### PR TITLE
Only enable external resources on RTD

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,8 @@ if __version__.endswith('dev'):
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('..'))
 
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
 # -- General configuration ------------------------------------------------
 
 
@@ -131,8 +133,14 @@ html_theme_options = {
     "description": "Load balancing and redundancy for Tor hidden services.",
     'github_user': 'DonnchaC',
     'github_repo': 'onionbalance',
-    'travis_button': True,
+    'github_button': False,
+    'travis_button': False,
 }
+
+# Enable external resources on the RTD hosted documentation only
+if on_rtd:
+    html_theme_options['github_button'] = True
+    html_theme_options['travis_button'] = True
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []


### PR DESCRIPTION
Locally built documentation should not make requests to external
services as this causes privacy problems for end users. Resolves #22.