### PR TITLE
Implement publishing distinct descriptors

### DIFF
--- a/docs/design.rst
+++ b/docs/design.rst
@@ -177,15 +177,17 @@ Tor onion service descriptors can include a maximum of 10 introduction
 points. OnionBalance should select introduction points so as to
 uniformly distribute load across the available backend instances.
 
+Onionbalance will upload multiple distinct descriptors if you have configured
+more than 10 instances.
+
 -  **1 instance** - 3 IPs
 -  **2 instance** - 6 IPs (3 IPs from each instance)
 -  **3 instance** - 9 IPs (3 IPs from each instance)
 -  **4 instance** - 10 IPs (3 IPs from one instance, 2 from each other
    instance)
 -  **5 instance** - 10 IPs (2 IPs from each instance)
--  **6-9 instances** - 10 IPs (selection from all instances)
--  **10 or more instances** - 1 IP from a random selection of 10
-   instances.
+-  **6-10 instances** - 10 IPs (selection from all instances)
+-  **11 or more instances** - 10 IPs (distinct descriptors - selection from all instances)
 
 If running in Complex mode, introduction points can be selected so as to
 obscure that a service is using OnionBalance. Always attempting to

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ Features
 OnionBalance is under active development and new features are being added
 regularly:
 
-- Load balancing between up to 10 backend hidden services
+- Load balancing between up to 60 backend hidden services
 - Storage of the hidden service private key separate to th hidden service
   hosts
 

--- a/docs/running-onionbalance.rst
+++ b/docs/running-onionbalance.rst
@@ -102,6 +102,17 @@ PUBLISH_CHECK_INTERVAL
   How often should to check if new descriptors need to be published for
   the master hidden service (default: 360 seconds).
 
+INITIAL_DELAY
+  How long to wait between starting OnionBalance and publishing the master
+  descriptor. If you have more than 20 backend instances you may need to wait
+  longer for all instance descriptors to download before starting
+  (default: 45 seconds).
+
+DISTINCT_DESCRIPTORS
+  Distinct descriptors are used if you have more than 10 backend instances.
+  At the cost of scalability, this can be disabled to appear more like a
+  standard onion service. (default: True)
+
 The following options typically do not need to be modified by the end user:
 
 REPLICAS

--- a/onionbalance/config.py
+++ b/onionbalance/config.py
@@ -8,6 +8,7 @@ Define default config options for the management server
 # Set default configuration options for the management server
 
 REPLICAS = 2
+HSDIR_SET = 3  # Publish each descriptor to 3 consecutive HSDirs
 MAX_INTRO_POINTS = 10
 DESCRIPTOR_VALIDITY_PERIOD = 24 * 60 * 60
 DESCRIPTOR_OVERLAP_PERIOD = 60 * 60
@@ -24,3 +25,5 @@ TOR_CONTROL_PASSWORD = None
 
 # Store global data about onion services and their instance nodes.
 services = []
+
+controller = None

--- a/onionbalance/config.py
+++ b/onionbalance/config.py
@@ -23,6 +23,10 @@ TOR_ADDRESS = '127.0.0.1'
 TOR_PORT = 9051
 TOR_CONTROL_PASSWORD = None
 
+# Upload multiple distinct descriptors containing different subsets of
+# the available introduction points
+distinct_descriptors = True
+
 # Store global data about onion services and their instance nodes.
 services = []
 

--- a/onionbalance/config.py
+++ b/onionbalance/config.py
@@ -15,6 +15,7 @@ DESCRIPTOR_OVERLAP_PERIOD = 60 * 60
 DESCRIPTOR_UPLOAD_PERIOD = 60 * 60  # Re-upload descriptor every hour
 REFRESH_INTERVAL = 10 * 60
 PUBLISH_CHECK_INTERVAL = 5 * 60
+INITIAL_DELAY = 45  # Wait for instance descriptors before publishing
 
 LOG_LOCATION = os.environ.get('ONIONBALANCE_LOG_LOCATION')
 LOG_LEVEL = os.environ.get('ONIONBALANCE_LOG_LEVEL', 'info')

--- a/onionbalance/config.py
+++ b/onionbalance/config.py
@@ -26,7 +26,7 @@ TOR_CONTROL_PASSWORD = None
 
 # Upload multiple distinct descriptors containing different subsets of
 # the available introduction points
-distinct_descriptors = True
+DISTINCT_DESCRIPTORS = True
 
 # Store global data about onion services and their instance nodes.
 services = []

--- a/onionbalance/consensus.py
+++ b/onionbalance/consensus.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+"""
+This module provides a set of functions for reading Tor consensus documents.
+"""
+from bisect import bisect_left
+import base64
+import binascii
+
+import stem
+import stem.descriptor
+
+import onionbalance.log as log
+import onionbalance.config as config
+
+logger = log.get_logger()
+
+HSDIR_LIST = []
+
+
+def refresh_consensus():
+    """
+    Update consensus state when Tor receives a new network status
+
+    Retrieve the current set of hidden service directories
+    """
+    global HSDIR_LIST
+
+    if not config.controller:
+        logger.warning("Controller connection not found in the configuration. "
+                       "Cannot update the Tor state.")
+        return None
+    else:
+        controller = config.controller
+
+    # pylint: disable=no-member
+    # Retrieve the current set of hidden service directories
+    hsdirs = []
+    try:
+        for desc in controller.get_network_statuses():
+            if stem.Flag.HSDIR in desc.flags:
+                hsdirs.append(desc.fingerprint)
+    except IOError as err:
+        logger.error("Could not load consensus from Tor: %s" % err)
+    else:
+        HSDIR_LIST = hsdirs
+        logger.debug("Updated the list of Tor hidden service directories.")
+
+
+def get_hsdirs(descriptor_id):
+    """
+    Get the responsible HSDirs for a given descriptor ID.
+    """
+
+    # Try fetch a consensus if we haven't loaded one already
+    if not HSDIR_LIST:
+        refresh_consensus()
+
+    if not HSDIR_LIST:
+        raise ValueError('Could not determine the responsible HSDirs.')
+
+    desc_id_bytes = base64.b32decode(descriptor_id, 1)
+    descriptor_id_hex = (binascii.hexlify(desc_id_bytes).
+                         decode('utf-8').upper())
+
+    responsible_hsdirs = []
+
+    # Find postion of descriptor ID in the HSDir list
+    index = descriptor_position = bisect_left(HSDIR_LIST, descriptor_id_hex)
+
+    # Pick HSDirs until we have enough
+    while len(responsible_hsdirs) < config.HSDIR_SET:
+        try:
+            responsible_hsdirs.append(HSDIR_LIST[index])
+            index += 1
+        except IndexError:
+            # Wrap around when we reach the end of the HSDir list
+            index = 0
+
+        # Do not choose a HSDir more than once
+        if index == descriptor_position:
+            break
+
+    return responsible_hsdirs

--- a/onionbalance/descriptor.py
+++ b/onionbalance/descriptor.py
@@ -98,8 +98,8 @@ def generate_service_descriptor(permanent_key, introduction_point_list=None,
     # Calculate the current secret-id-part for this hidden service
     # Deviation allows the generation of a descriptor for a different time
     # period.
-    time_period = (util.get_time_period(unix_timestamp, permanent_id)
-                   + int(deviation))
+    time_period = (util.get_time_period(unix_timestamp, permanent_id) +
+                   int(deviation))
 
     secret_id_part = util.calc_secret_id_part(time_period, None, replica)
     descriptor_id = util.calc_descriptor_id(permanent_id, secret_id_part)
@@ -226,8 +226,8 @@ def sign_descriptor(descriptor, service_key):
 
     # Remove signature block if it exists
     if token_descriptor_signature in descriptor:
-        descriptor = descriptor[:descriptor.find(token_descriptor_signature)
-                                + len(token_descriptor_signature)]
+        descriptor = descriptor[:descriptor.find(token_descriptor_signature) +
+                                len(token_descriptor_signature)]
     else:
         descriptor = descriptor.strip() + token_descriptor_signature
 

--- a/onionbalance/descriptor.py
+++ b/onionbalance/descriptor.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
+from future.moves.itertools import zip_longest
 import hashlib
 import base64
 import textwrap
 import datetime
 import random
+import itertools
 
 import Crypto.Util.number
 import stem
@@ -15,59 +17,69 @@ from onionbalance import config
 logger = log.get_logger()
 
 
-def choose_introduction_point_set(available_introduction_points):
+class IntroductionPointSet(object):
     """
-    Select a set introduction points to included in a HS descriptor.
+    Select a set of introduction points to included in a HS descriptor.
 
     Provided with a list of available introduction points for each
-    backend instance for an onionbalance service.
+    backend instance for an onionbalance service. This object will store
+    the set of available introduction points and allow IPs to be selected
+    from the available set.
 
-    Introduciton points are selected to try and achieve the greatest
-    distribution of introduction points across all of the available backend
-    instances.
-
-    Return a list of IntroductionPoints.
+    This class tracks which introduction points have already been provided
+    and tries to provide the most diverse set of IPs.
     """
 
-    # Shuffle the instance order before beginning to pick intro points
-    random.shuffle(available_introduction_points)
+    def __init__(self, available_introduction_points):
+        # Shuffle the introduction point order before selecting IPs.
+        # Randomizing now allows later calls to .choose() to be
+        # deterministic.
+        for instance_intro_points in available_introduction_points:
+            random.shuffle(instance_intro_points)
+        random.shuffle(available_introduction_points)
 
-    num_active_instances = len(available_introduction_points)
-    ips_per_instance = [len(ips) for ips in available_introduction_points]
-    num_intro_points = sum(ips_per_instance)
+        self.available_intro_points = available_introduction_points
+        self.intro_point_generator = self.get_intro_point()
 
-    # Choose up to `MAX_INTRO_POINTS` IPs from the service instances. If less
-    # than `MAX_INTRO_POINTS` IPs are available, we should pick all available
-    # IP's
-    max_introduction_points = min(num_intro_points,
-                                  config.MAX_INTRO_POINTS)
+    def __len__(self):
+        """Provide the total number of available introduction points"""
+        return sum(len(ips) for ips in self.available_intro_points)
 
-    # Determine the maximum number of IP's which can be selected from
-    # each instance to give the widest distribution of introduction
-    # point
-    pos = 0
-    intro_selection = [0] * num_active_instances
+    def get_intro_point(self):
+        """
+        Generator function which yields an introduction point
 
-    # Keep looping until we have selected enough introduction points
-    while sum(intro_selection) < max_introduction_points:
-        # Check if the current instance has more IPs available
-        if(ips_per_instance[pos] - intro_selection[pos] > 0):
-            intro_selection[pos] += 1
-        # Increment and wrap the pointer to the current instance
-        pos = ((pos + 1) % num_active_instances)
+        Iterates through all available introduction points and try
+        to pick IPs breath first across all backend instances. The
+        intro point set is wrapped in `itertools.cycle` and will provided
+        an infinite series of introduction points.
+        """
 
-    # intro_selection now lists the count/number of IPs to select from each
-    # instance. We now sample the determined number of IPs from the IPs
-    # available for each instance.
-    choosen_intro_points = []
-    for count, intros in zip(intro_selection, available_introduction_points):
-        choosen_intro_points.extend(random.sample(intros, count))
+        # Combine intro points from across the backend instances and flatten
+        intro_points = zip_longest(*self.available_intro_points)
+        flat_intro_points = itertools.chain.from_iterable(intro_points)
+        for intro_point in itertools.cycle(flat_intro_points):
+            if intro_point:
+                yield intro_point
 
-    # Shuffle choosen IP's to try reveal less information about which
-    # instances are online and have introduction points included.
-    random.shuffle(choosen_intro_points)
+    def choose(self, count=10, shuffle=True):
+        """
+        Retrieve N introduction points from the set of IPs
 
-    return choosen_intro_points
+        Where more than `count` IPs are available, introduction points are
+        selected to try and achieve the greatest distribution of introduction
+        points across all of the available backend instances.
+
+        Return a list of IntroductionPoints.
+        """
+
+        # Limit `count` to the available number of IPs to avoid repeats.
+        count = min(len(self), count)
+        choosen_ips = list(itertools.islice(self.intro_point_generator, count))
+
+        if shuffle:
+            random.shuffle(choosen_ips)
+        return choosen_ips
 
 
 def generate_service_descriptor(permanent_key, introduction_point_list=None,

--- a/onionbalance/eventhandler.py
+++ b/onionbalance/eventhandler.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 from builtins import str, object
 
+import stem
+
 from onionbalance import log
 from onionbalance import descriptor
+from onionbalance import consensus
 
 logger = log.get_logger()
 
@@ -12,6 +15,17 @@ class EventHandler(object):
     """
     Handles asynchronous Tor events.
     """
+
+    @staticmethod
+    def new_status(status_event):
+        """
+        Parse Tor status events such as "STATUS_GENERAL"
+        """
+        # pylint: disable=no-member
+        if status_event.status_type == stem.StatusType.GENERAL:
+            if status_event.action == "CONSENSUS_ARRIVED":
+                # Update the local view of the consensus in OnionBalance
+                consensus.refresh_consensus()
 
     @staticmethod
     def new_desc(desc_event):

--- a/onionbalance/manager.py
+++ b/onionbalance/manager.py
@@ -117,6 +117,8 @@ def main():
     # Finished parsing all the config file.
 
     handler = eventhandler.EventHandler()
+    controller.add_event_listener(handler.new_status,
+                                  EventType.STATUS_GENERAL)
     controller.add_event_listener(handler.new_desc,
                                   EventType.HS_DESC)
     controller.add_event_listener(handler.new_desc_content,

--- a/onionbalance/manager.py
+++ b/onionbalance/manager.py
@@ -132,7 +132,7 @@ def main():
 
     try:
         # Run initial fetch of HS instance descriptors
-        schedule.run_all(delay_seconds=30)
+        schedule.run_all(delay_seconds=config.INITIAL_DELAY)
 
         # Begin main loop to poll for HS descriptors
         while True:

--- a/onionbalance/service.py
+++ b/onionbalance/service.py
@@ -143,7 +143,7 @@ class Service(object):
         # Upload multiple unique descriptors which contain different
         # subsets of the available introduction points.
         # (https://github.com/DonnchaC/onionbalance/issues/16)
-        distinct_descriptors = config.distinct_descriptors
+        distinct_descriptors = config.DISTINCT_DESCRIPTORS
 
         # If we have <= MAX_INTRO_POINTS we should choose the introduction
         # points now and use the same set in every descriptor. Using the

--- a/onionbalance/service.py
+++ b/onionbalance/service.py
@@ -10,6 +10,7 @@ from onionbalance import descriptor
 from onionbalance import util
 from onionbalance import log
 from onionbalance import config
+from onionbalance import consensus
 
 logger = log.get_logger()
 
@@ -95,6 +96,9 @@ class Service(object):
     def _select_introduction_points(self):
         """
         Choose set of introduction points from all fresh descriptors
+
+        Returns a descriptor.IntroductionPointSet() which can be used to
+        choose introduction points.
         """
         available_intro_points = []
 
@@ -125,49 +129,108 @@ class Service(object):
                 instance.changed_since_published = False
                 available_intro_points.append(instance.introduction_points)
 
-        num_intro_points = sum(len(ips) for ips in available_intro_points)
-        choosen_intro_points = descriptor.choose_introduction_point_set(
-            available_intro_points)
-
-        logger.debug("Selected %d IPs of %d for service %s.onion.",
-                     len(choosen_intro_points), num_intro_points,
-                     self.onion_address)
-
-        return choosen_intro_points
+        return descriptor.IntroductionPointSet(available_intro_points)
 
     def _publish_descriptor(self, deviation=0):
         """
-        Create, sign and uploads a master descriptor for this service
+        Create, sign and upload master descriptors for this service
         """
-        introduction_points = self._select_introduction_points()
+
+        # Retrieve the set of available introduction points
+        intro_point_set = self._select_introduction_points()
+        max_intro_points = config.MAX_INTRO_POINTS
+
+        # Upload multiple unique descriptors which contain different
+        # subsets of the available introduction points.
+        # (https://github.com/DonnchaC/onionbalance/issues/16)
+        distinct_descriptors = config.distinct_descriptors
+
+        # If we have <= MAX_INTRO_POINTS we should choose the introduction
+        # points now and use the same set in every descriptor. Using the
+        # same set of introduction points will look more like a standard
+        # Tor client.
+        num_intro_points = len(intro_point_set)
+
+        if len(intro_point_set) <= max_intro_points:
+            intro_points = intro_point_set.choose(num_intro_points)
+            logger.debug("We have %d IPs, not using distinct descriptors.",
+                         len(intro_point_set))
+            distinct_descriptors = False
+
         for replica in range(0, config.REPLICAS):
-            try:
-                signed_descriptor = descriptor.generate_service_descriptor(
-                    self.service_key,
-                    introduction_point_list=introduction_points,
+            # Using distinct descriptors, choose a new set of intro points
+            # for each descriptor and upload it to individual HSDirs.
+            if distinct_descriptors:
+                descriptor_id = util.calc_descriptor_id_b32(
+                    self.onion_address,
+                    time=time.time(),
                     replica=replica,
-                    deviation=deviation
+                    deviation=deviation,
                 )
-            except ValueError as exc:
-                logger.warning("Error generating master descriptor: %s", exc)
+                responsible_hsdirs = consensus.get_hsdirs(descriptor_id)
+
+                for hsdir in responsible_hsdirs:
+                    intro_points = intro_point_set.choose(max_intro_points)
+                    try:
+                        signed_descriptor = (
+                            descriptor.generate_service_descriptor(
+                                self.service_key,
+                                introduction_point_list=intro_points,
+                                replica=replica,
+                                deviation=deviation
+                            ))
+                    except ValueError as exc:
+                        logger.warning("Error generating descriptor: %s", exc)
+                        continue
+
+                    # Signed descriptor was generated successfully, upload it
+                    # to the respective HSDir
+                    self._upload_descriptor(signed_descriptor, replica,
+                                            hsdirs=hsdir)
+                logger.info("Published distinct master descriptors for "
+                            "service %s.onion under replica %d.",
+                            self.onion_address, replica)
+
             else:
-                # Signed descriptor was generated successfully, upload it
+                # Not using distinct descriptors, upload one descriptor
+                # under each replica and let Tor pick the HSDirs.
                 try:
-                    descriptor.upload_descriptor(self.controller,
-                                                 signed_descriptor)
-                except stem.ControllerError:
-                    logger.exception("Error uploading descriptor for service "
-                                     "%s.onion.", self.onion_address)
-                else:
-                    logger.info("Published a descriptor for service "
-                                "%s.onion under replica %d.",
-                                self.onion_address, replica)
+                    signed_descriptor = descriptor.generate_service_descriptor(
+                        self.service_key,
+                        introduction_point_list=intro_points,
+                        replica=replica,
+                        deviation=deviation
+                    )
+                except ValueError as exc:
+                    logger.warning("Error generating descriptor: %s", exc)
+                    continue
+
+                # Signed descriptor was generated successfully, upload it
+                self._upload_descriptor(signed_descriptor, replica)
+                logger.info("Published a descriptor for service %s.onion "
+                            "under replica %d.", self.onion_address, replica)
 
         # It would be better to set last_uploaded when an upload succeeds and
         # not when an upload is just attempted. Unfortunately the HS_DESC #
         # UPLOADED event does not provide information about the service and
         # so it can't be used to determine when descriptor upload succeeds
         self.uploaded = datetime.datetime.utcnow()
+
+    def _upload_descriptor(self, signed_descriptor, replica, hsdirs=None):
+        """
+        Convenience method to upload a descriptor
+
+        Handle some error checking and logging inside the Service class
+        """
+        if hsdirs and not isinstance(hsdirs, list):
+            hsdirs = [hsdirs]
+
+        try:
+            descriptor.upload_descriptor(self.controller, signed_descriptor,
+                                         hsdirs=hsdirs)
+        except stem.ControllerError:
+            logger.exception("Error uploading descriptor for service "
+                             "%s.onion.", self.onion_address)
 
     def descriptor_publish(self, force_publish=False):
         """

--- a/onionbalance/service.py
+++ b/onionbalance/service.py
@@ -151,7 +151,7 @@ class Service(object):
         # Tor client.
         num_intro_points = len(intro_point_set)
 
-        if len(intro_point_set) <= max_intro_points:
+        if num_intro_points <= max_intro_points:
             intro_points = intro_point_set.choose(num_intro_points)
             logger.debug("We have %d IPs, not using distinct descriptors.",
                          len(intro_point_set))

--- a/onionbalance/settings.py
+++ b/onionbalance/settings.py
@@ -105,6 +105,9 @@ def initialize_services(controller, services_config):
             instances=instances
         ))
 
+        # Store a global reference to current controller connection
+        config.controller = controller
+
 
 def parse_cmd_args():
     """

--- a/onionbalance/util.py
+++ b/onionbalance/util.py
@@ -75,6 +75,23 @@ def calc_secret_id_part(time_period, descriptor_cookie, replica):
     return secret_id_part.digest()
 
 
+def calc_descriptor_id_b32(onion_address, time, replica, deviation=0,
+                           descriptor_cookie=None):
+    """
+    High level function to calculate the descriptor ID for a hidden
+    service.
+
+    The onion address and returned descriptor ID are both base32 encoded.
+    """
+    permanent_id = base64.b32decode(onion_address, 1)
+    time_period = get_time_period(time, permanent_id) + int(deviation)
+    secret_id_part = calc_secret_id_part(time_period, descriptor_cookie,
+                                         replica)
+    descriptor_id = calc_descriptor_id(permanent_id, secret_id_part)
+
+    return base64.b32encode(descriptor_id).decode('utf-8').lower()
+
+
 def rounded_timestamp(timestamp=None):
     """
     Create timestamp rounded down to the nearest hour

--- a/test/test_consensus.py
+++ b/test/test_consensus.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from onionbalance import consensus
+from onionbalance import config
+
+# Mock hex-encoded HSDir fingerprint list
+MOCK_HSDIR_LIST = [
+    "1111111111111111111111111111111111111111",
+    "2222222222222222222222222222222222222222",
+    "3333333333333333333333333333333333333333",
+    "4444444444444444444444444444444444444444",
+    "5555555555555555555555555555555555555555",
+    "6666666666666666666666666666666666666666",
+]
+
+config.HSDIR_SET = 3  # Always select 3 responsible HSDirs
+
+
+def test_get_hsdirs_no_consensus():
+    """
+    `get_hsdirs` should raise an exception when we don't have a valid
+    HSDir list from the consensus.
+    """
+
+    with pytest.raises(ValueError):
+        consensus.get_hsdirs('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+
+
+def test_get_hsdirs(monkeypatch):
+    """Test for normal responsible HSDir selection"""
+
+    monkeypatch.setattr(consensus, 'HSDIR_LIST', MOCK_HSDIR_LIST)
+
+    # Descriptor ID before '222....''
+    descriptor_id_base32 = "eiqaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    responsible_hsdirs = consensus.get_hsdirs(descriptor_id_base32)
+
+    assert (responsible_hsdirs == [
+        "2222222222222222222222222222222222222222",
+        "3333333333333333333333333333333333333333",
+        "4444444444444444444444444444444444444444",
+    ])
+
+
+def test_get_hsdirs_edge_of_ring(monkeypatch):
+    """Test that selection wraps around the edge of the HSDir ring"""
+
+    monkeypatch.setattr(consensus, 'HSDIR_LIST', MOCK_HSDIR_LIST)
+
+    # Descriptor ID before '666....''
+    descriptor_id_base32 = "mzqaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    responsible_hsdirs = consensus.get_hsdirs(descriptor_id_base32)
+
+    assert (responsible_hsdirs == [
+        "6666666666666666666666666666666666666666",
+        "1111111111111111111111111111111111111111",
+        "2222222222222222222222222222222222222222",
+    ])
+
+
+def test_get_hsdirs_no_repeat(monkeypatch):
+    """Test that selection wraps around the edge of the HSDir ring"""
+
+    SHORT_HSDIR_LIST = [
+        "1111111111111111111111111111111111111111",
+        "2222222222222222222222222222222222222222",
+    ]
+    monkeypatch.setattr(consensus, 'HSDIR_LIST', SHORT_HSDIR_LIST)
+
+    # Descriptor ID before '111....''
+    descriptor_id_base32 = "ceiaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    responsible_hsdirs = consensus.get_hsdirs(descriptor_id_base32)
+
+    assert (responsible_hsdirs == [
+        "1111111111111111111111111111111111111111",
+        "2222222222222222222222222222222222222222",
+    ])

--- a/test/test_descriptor.py
+++ b/test/test_descriptor.py
@@ -224,9 +224,11 @@ def test_introduction_point_selection(intro_point_distribution,
 
     intro_set = descriptor.IntroductionPointSet(available_intro_points)
 
-    # Max 10 introduction points per descriptor
-    choosen_intro_points = intro_set.choose(10)
-    assert len(choosen_intro_points) == selected_ip_count
+    # Check that we can fetch the same number for each descriptor
+    for i in range(0, 2):
+        # Max 10 introduction points per descriptor
+        choosen_intro_points = intro_set.choose(10)
+        assert len(choosen_intro_points) == selected_ip_count
 
 
 def test_generate_service_descriptor(monkeypatch, mocker):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -163,6 +163,36 @@ def test_calc_descriptor_id():
             b'f58ce3c63ee634e1ffaf936251a822ff06385f55')
 
 
+def test_calc_descriptor_id_full():
+
+    descriptor_id = calc_descriptor_id_b32(
+        onion_address='jyvfq5umznvka34v',
+        time=UNIX_TIMESTAMP,
+        replica=0)
+
+    assert descriptor_id == '6wgohrr64y2od75psnrfdkbc74ddqx2v'
+
+
+def test_calc_descriptor_id_full_replica():
+    descriptor_id = calc_descriptor_id_b32(
+        onion_address='jyvfq5umznvka34v',
+        time=UNIX_TIMESTAMP,
+        replica=1)
+
+    assert descriptor_id == 'he35m4nouhkz6thymvhdvc3y5htqs422'
+
+
+def test_calc_descriptor_id_full_with_deviation():
+
+    descriptor_id = calc_descriptor_id_b32(
+        onion_address='jyvfq5umznvka34v',
+        time=UNIX_TIMESTAMP,
+        replica=0,
+        deviation=1)
+
+    assert descriptor_id == 'esnnz2q6dnfwprvc4qhsgsfzz6r6ksrt'
+
+
 def test_rounded_timestamp():
     timestamp = datetime.datetime(2015, 6, 25, 13, 13, 25)
     assert rounded_timestamp(timestamp) == u'2015-06-25 13:00:00'


### PR DESCRIPTION
This branch adds the feature to generate multiple distinct descriptors. When more than 10 IPs are available a different subset will be included in descriptor uploaded to each of the 6 hidden service directories.

This distinct descriptors features allows up to 60 (10 x 6) backend hidden services instances to be accessible by clients at any time.

Resolves #16.