### PR TITLE
Add signal support and a service status socket server

### DIFF
--- a/docs/running-onionbalance.rst
+++ b/docs/running-onionbalance.rst
@@ -113,6 +113,12 @@ DISTINCT_DESCRIPTORS
   At the cost of scalability, this can be disabled to appear more like a
   standard onion service. (default: True)
 
+STATUS_SOCKET_LOCATION
+  The OnionBalance service creates a Unix domain socket which provides
+  real-time information about the currently loaded service and descriptors.
+  This option can be used to change the location of this domain socket.
+  (default: /var/run/onionbalance/control)
+
 The following options typically do not need to be modified by the end user:
 
 REPLICAS
@@ -148,6 +154,9 @@ ONIONBALANCE_LOG_LOCATION
   See the config file option.
 
 ONIONBALANCE_LOG_LEVEL
+  See the config file option
+
+ONIONBALANCE_STATUS_SOCKET_LOCATION
   See the config file option
 
 

--- a/onionbalance/config.py
+++ b/onionbalance/config.py
@@ -20,6 +20,9 @@ INITIAL_DELAY = 45  # Wait for instance descriptors before publishing
 LOG_LOCATION = os.environ.get('ONIONBALANCE_LOG_LOCATION')
 LOG_LEVEL = os.environ.get('ONIONBALANCE_LOG_LEVEL', 'info')
 
+STATUS_SOCKET_LOCATION = os.environ.get('ONIONBALANCE_STATUS_SOCKET_LOCATION',
+                                        '/var/run/onionbalance/control')
+
 TOR_ADDRESS = '127.0.0.1'
 TOR_PORT = 9051
 TOR_CONTROL_PASSWORD = None

--- a/onionbalance/eventhandler.py
+++ b/onionbalance/eventhandler.py
@@ -69,11 +69,12 @@ class SignalHandler(object):
     Handle signals sent to the OnionBalance daemon process
     """
 
-    def __init__(self, controller):
+    def __init__(self, controller, status_socket):
         """
         Setup signal handler
         """
-        self.__tor_controller = controller
+        self._tor_controller = controller
+        self._status_socket = status_socket
 
         # Register signal handlers
         signal.signal(signal.SIGTERM, self._handle_sigint_sigterm)
@@ -86,6 +87,7 @@ class SignalHandler(object):
         Disconnect from control port and cleanup the status socket
         """
         logger.info("Signal %d received, exiting", signum)
-        self.__tor_controller.close()
+        self._tor_controller.close()
+        self._status_socket.close()
         logging.shutdown()
         sys.exit(0)

--- a/onionbalance/eventhandler.py
+++ b/onionbalance/eventhandler.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 from builtins import str, object
+import logging
+import signal
+import sys
 
 import stem
 
@@ -59,3 +62,30 @@ class EventHandler(object):
         descriptor.descriptor_received(descriptor_text)
 
         return None
+
+
+class SignalHandler(object):
+    """
+    Handle signals sent to the OnionBalance daemon process
+    """
+
+    def __init__(self, controller):
+        """
+        Setup signal handler
+        """
+        self.__tor_controller = controller
+
+        # Register signal handlers
+        signal.signal(signal.SIGTERM, self._handle_sigint_sigterm)
+        signal.signal(signal.SIGINT, self._handle_sigint_sigterm)
+
+    def _handle_sigint_sigterm(self, signum, frame):
+        """
+        Handle SIGINT (Ctrl-C) and SIGTERM
+
+        Disconnect from control port and cleanup the status socket
+        """
+        logger.info("Signal %d received, exiting", signum)
+        self.__tor_controller.close()
+        logging.shutdown()
+        sys.exit(0)

--- a/onionbalance/manager.py
+++ b/onionbalance/manager.py
@@ -7,7 +7,6 @@ each instance.
 import os
 import sys
 import argparse
-import time
 import logging
 
 # import Crypto.PublicKey
@@ -91,6 +90,8 @@ def main():
     else:
         logger.debug("Successfully connected to the Tor control port.")
 
+    eventhandler.SignalHandler(controller)
+
     try:
         controller.authenticate(password=config.TOR_CONTROL_PASSWORD)
     except stem.connection.AuthenticationFailure as exc:
@@ -130,15 +131,11 @@ def main():
     schedule.every(config.PUBLISH_CHECK_INTERVAL).seconds.do(
         onionbalance.service.publish_all_descriptors)
 
-    try:
-        # Run initial fetch of HS instance descriptors
-        schedule.run_all(delay_seconds=config.INITIAL_DELAY)
+    # Run initial fetch of HS instance descriptors
+    schedule.run_all(delay_seconds=config.INITIAL_DELAY)
 
-        # Begin main loop to poll for HS descriptors
-        while True:
-            schedule.run_pending()
-            time.sleep(1)
-    except KeyboardInterrupt:
-        logger.info("Keyboard interrupt received. Stopping the "
-                    "management server.")
+    # Begin main loop to poll for HS descriptors
+    while True:
+        schedule.run_pending()
+
     return 0

--- a/onionbalance/manager.py
+++ b/onionbalance/manager.py
@@ -136,6 +136,9 @@ def main():
 
     # Begin main loop to poll for HS descriptors
     while True:
-        schedule.run_pending()
+        try:
+            schedule.run_pending()
+        except Exception:
+            logger.error("Unexpected exception:", exc_info=True)
 
     return 0

--- a/onionbalance/manager.py
+++ b/onionbalance/manager.py
@@ -18,6 +18,7 @@ from onionbalance import log
 from onionbalance import settings
 from onionbalance import config
 from onionbalance import eventhandler
+from onionbalance import status
 
 import onionbalance.service
 import onionbalance.instance
@@ -90,8 +91,6 @@ def main():
     else:
         logger.debug("Successfully connected to the Tor control port.")
 
-    eventhandler.SignalHandler(controller)
-
     try:
         controller.authenticate(password=config.TOR_CONTROL_PASSWORD)
     except stem.connection.AuthenticationFailure as exc:
@@ -99,6 +98,9 @@ def main():
         sys.exit(1)
     else:
         logger.debug("Successfully authenticated to the Tor control port.")
+
+    status_socket = status.StatusSocket(config.STATUS_SOCKET_LOCATION)
+    eventhandler.SignalHandler(controller, status_socket)
 
     # Disable no-member due to bug with "Instance of 'Enum' has no * member"
     # pylint: disable=no-member

--- a/onionbalance/status.py
+++ b/onionbalance/status.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+# OnionBalance - Status
+# Copyright: 2015 Federico Ceratto
+# Released under GPLv3, see COPYING file
+
+"""
+Provide status over Unix socket
+Default path: /var/run/onionbalance/control
+"""
+import os
+import errno
+import threading
+from socketserver import BaseRequestHandler, ThreadingMixIn, UnixStreamServer
+
+from onionbalance import log
+from onionbalance import config
+
+logger = log.get_logger()
+
+
+class StatusSocketHandler(BaseRequestHandler):
+    """
+    Handler for new domain socket connections
+    """
+    def handle(self):
+        """
+        Prepare and output the status summary when a connection is received
+        """
+        time_format = "%Y-%m-%d %H:%M:%S"
+        response = []
+        for service in config.services:
+            if service.uploaded:
+                service_timestamp = service.uploaded.strftime(time_format)
+            else:
+                service_timestamp = "[not uploaded]"
+            response.append("{}.onion {}".format(service.onion_address,
+                                                 service_timestamp))
+
+            for instance in service.instances:
+                if not instance.timestamp:
+                    response.append("  {}.onion [offline]".format(
+                        instance.onion_address))
+                else:
+                    response.append("  {}.onion {} {} IPs".format(
+                        instance.onion_address,
+                        instance.timestamp.strftime(time_format),
+                        len(instance.introduction_points)))
+        response.append("")
+        self.request.sendall('\n'.join(response).encode('utf-8'))
+
+
+class ThreadingSocketServer(ThreadingMixIn, UnixStreamServer):
+    """
+    Unix socket server with threading
+    """
+    pass
+
+
+class StatusSocket(object):
+    """
+    Create a Unix domain socket which emits a summary of the OnionBalance
+    status when a client connects.
+    """
+
+    def __init__(self, status_socket_location):
+        """
+        Create the Unix domain socket status server and start in a thread
+
+        Example::
+            socat - unix-connect:/var/run/onionbalance/control
+
+            uweyln7jhkyaokka.onion 2016-05-01 11:08:56
+              r523s7jx65ckitf4.onion [offline]
+              v2q7ujuleky7odph.onion 2016-05-01 11:00:00 3 IPs
+        """
+        self.unix_socket_filename = status_socket_location
+        self.cleanup_socket_file()
+
+        logger.debug("Creating status socket at %s", self.unix_socket_filename)
+        try:
+            self.server = ThreadingSocketServer(self.unix_socket_filename,
+                                                StatusSocketHandler)
+
+            # Start running the socket server in a another thread
+            server_thread = threading.Thread(target=self.server.serve_forever)
+            server_thread.daemon = True  # Exit daemon when main thread stops
+            server_thread.start()
+
+        except OSError:
+            logger.error("Could not start status socket at %s. Do you have "
+                         "permission?", status_socket_location)
+
+    def cleanup_socket_file(self):
+        """
+        Try to remove the socket file if it exists already
+        """
+        try:
+            os.unlink(self.unix_socket_filename)
+        except OSError as e:
+            # Reraise if its not a FileNotFound exception
+            if e.errno != errno.ENOENT:
+                raise
+
+    def close(self):
+        """
+        Close the unix domain socket and remove its file
+        """
+        try:
+            self.server.shutdown()
+            self.server.server_close()
+            self.cleanup_socket_file()
+        except OSError:
+            logger.exception("Error when removing the status socket")


### PR DESCRIPTION
It can be difficult to find out the current state of the OnionBalance daemon. This pull request adds a Unix domain socket which outputs the service status when a client connects. By default this socket is created at `/var/run/onionbalance/control`.

Socat can be used to connect to the unix socket:
```
$ socat - unix-connect:/var/run/onionbalance/control
uweyln7jhkyaokka.onion 2016-05-01 11:08:56
  r523s7jx65ckitf4.onion [offline]
  v2q7ujuleky7odph.onion 2016-05-01 11:00:00 3 IPs
  h3gta5eyyckzjutl [offline]
```

This pull request also adds signal support to graceful shutdown the service when a keyboard interupt or SIGTERM is received.

Thank you very much to Federico Ceratto for the signal support and original socket implementation.

Closes #25 and #26.