### PR TITLE
Add support for connections to Tor over a unix domain socket

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+UNRELEASED
+----------
+
+- Add support for connecting to the Tor control port over a unix domain socket.
+
 0.1.4
 -----
 

--- a/docs/running-onionbalance.rst
+++ b/docs/running-onionbalance.rst
@@ -84,6 +84,30 @@ you can simply use the generated config file from ``master/config.yaml``.
 Configuration Options
 ~~~~~~~~~~~~~~~~~~~~~
 
+The OnionBalance command line options can also be specified in the
+OnionBalance configuration file. Options specified on the command line
+take precedence over the related configuration file options:
+
+TOR_CONTROL_SOCKET:
+  The location of the Tor unix domain control socket. OnionBalance will
+  attempt to connect to this control socket first before falling back to
+  using a control port connection.
+  (default: /var/run/tor/control)
+
+TOR_ADDRESS:
+  The address where the Tor control port is listening. (default: 127.0.0.1)
+
+TOR_PORT:
+  The Tor control port. (default: 9051)
+
+TOR_CONTROL_PASSWORD:
+  The password for authenticating to a Tor control port which is using the
+  HashedControlPassword authentication method. This is not needed when the
+  Tor control port is using the more common CookieAuthentication method.
+  (default: None)
+
+Other options:
+
 LOG_LOCATION
   The path where OnionBalance should write its log file.
 
@@ -157,6 +181,9 @@ ONIONBALANCE_LOG_LEVEL
   See the config file option
 
 ONIONBALANCE_STATUS_SOCKET_LOCATION
+  See the config file option
+
+ONIONBALANCE_TOR_CONTROL_SOCKET
   See the config file option
 
 

--- a/onionbalance/config.py
+++ b/onionbalance/config.py
@@ -26,6 +26,8 @@ STATUS_SOCKET_LOCATION = os.environ.get('ONIONBALANCE_STATUS_SOCKET_LOCATION',
 TOR_ADDRESS = '127.0.0.1'
 TOR_PORT = 9051
 TOR_CONTROL_PASSWORD = None
+TOR_CONTROL_SOCKET = os.environ.get('ONIONBALANCE_TOR_CONTROL_SOCKET',
+                                    '/var/run/tor/control')
 
 # Upload multiple distinct descriptors containing different subsets of
 # the available introduction points


### PR DESCRIPTION
OnionBalance will now automatically try to connect to a local Tor unix domain control socket before falling back to using a Tor control port connection.

This commit also adds some documentation describing how the OnionBalance command line options can also be specified in the configuration file.

Resolves #35.