### PR TITLE
Always remove .onion extension from instance addresses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 UNRELEASED
 ----------
 
+- Fix bug loading descriptors when an address with .onion extension is listed
+  in the configuration file. #37
 - Add support for connecting to the Tor control port over a unix domain socket.
 
 0.1.4

--- a/onionbalance/instance.py
+++ b/onionbalance/instance.py
@@ -38,6 +38,8 @@ class Instance(object):
         self.controller = controller
 
         # Onion address for the service instance.
+        if onion_address:
+            onion_address = onion_address.strip('.onion')
         self.onion_address = onion_address
         self.authentication_cookie = authentication_cookie
 


### PR DESCRIPTION
This commit removes any .onion extensions from onion addresses specified in the configuration file.

Resolves #37.