### PR TITLE
correctly remove .onion from instances

### DIFF
--- a/onionbalance/instance.py
+++ b/onionbalance/instance.py
@@ -39,7 +39,7 @@ class Instance(object):
 
         # Onion address for the service instance.
         if onion_address:
-            onion_address = onion_address.strip('.onion')
+            onion_address = onion_address.replace('.onion', '')
         self.onion_address = onion_address
         self.authentication_cookie = authentication_cookie
 


### PR DESCRIPTION
`strip` strips any of the passed characters from the string. So if
you have a hostname containing `on` or - as in my case - `...no`
you will end up with a broken onionservice hostname for onionbalance.