### PR TITLE
Fix major bug in instance address parsing

### DIFF
--- a/onionbalance/instance.py
+++ b/onionbalance/instance.py
@@ -39,7 +39,7 @@ class Instance(object):
 
         # Onion address for the service instance.
         if onion_address:
-            onion_address = onion_address.strip('.onion')
+            onion_address = onion_address.replace('.onion', '')
         self.onion_address = onion_address
         self.authentication_cookie = authentication_cookie
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands = py.test --cov-report=term-missing --cov=onionbalance {posargs}
 basepython=python
 changedir=docs
 deps=sphinx
-     sphinxcontrib-autoprogram
+     sphinxcontrib-autoprogram==0.1.2
 commands=
     sphinx-build -W -b html -d {envtmpdir}/docs . {envtmpdir}/html
 


### PR DESCRIPTION
I introduced a bug in cbda349 which causes instance address parsing to fail if the address ends with any of the letters in ".onion". The correct behavior is to strip the string ".onion" from the end of the address. 

Thank you to duritong and Alec Muffett for reporting this.

Resolves #43.
