### PR TITLE
Add healthchecking

### DIFF
--- a/onionbalance/config.py
+++ b/onionbalance/config.py
@@ -15,6 +15,7 @@ DESCRIPTOR_OVERLAP_PERIOD = 60 * 60
 DESCRIPTOR_UPLOAD_PERIOD = 60 * 60  # Re-upload descriptor every hour
 REFRESH_INTERVAL = 10 * 60
 PUBLISH_CHECK_INTERVAL = 5 * 60
+HEALTH_CHECK_INTERVAL = 60
 INITIAL_DELAY = 45  # Wait for instance descriptors before publishing
 
 LOG_LOCATION = os.environ.get('ONIONBALANCE_LOG_LOCATION')

--- a/onionbalance/healthchecks.py
+++ b/onionbalance/healthchecks.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+# OnionBalance - Service health checking
+# Copyright: 2015 Federico Ceratto
+# Released under GPLv3, see COPYING file
+#
+# Requires python3-socks - https://github.com/Anorov/PySocks
+
+"""
+Check service health using TCP, HTTP, HTTPS
+"""
+
+import urllib.request
+import socket
+from time import time
+
+from onionbalance import log
+import onionbalance
+
+try:
+    import socks
+    from sockshandler import SocksiPyHandler
+    socks_available = True
+except ImportError:
+    socks_available = False
+
+logger = log.get_logger()
+
+USER_AGENT_HEADER = 'OnionBalance/%s' % onionbalance.__version__
+
+
+def check_tcp(onion_addr, port_number, timeout):
+    """Check for Onion Service connectivity with a TCP connect
+    """
+    if not socks_available:
+        logger.error("please install the pysocks library")
+        return
+
+    s = socks.socksocket()
+    s.set_proxy(socks.SOCKS5, "127.0.0.1", 9050)
+    s.settimeout(timeout)
+    logger.debug("Checking TCP %s:%d", onion_addr, port_number)
+    try:
+        t = time()
+        s.connect(("%s.onion" % onion_addr, port_number))
+        delta = time() - t
+        is_healthy = True
+    except:
+        delta = time() - t
+        is_healthy = False
+    finally:
+        s.close()
+
+    return is_healthy, t, delta
+
+
+def _check_url(url, timeout):
+    """Check for HTTP[S] connectivity over Tor"""
+
+    opener = urllib.request.build_opener(SocksiPyHandler(socks.SOCKS5, "127.0.0.1", 9050))
+    opener.addheaders = [('User-agent', USER_AGENT_HEADER)]
+    logger.debug("Checking %s", url)
+    try:
+        t = time()
+        opener.open(url, None, timeout).read(1024)
+        is_healthy = True
+    except Exception as e:
+        logger.debug("Check exception %s", e)
+        is_healthy = False
+
+    return is_healthy, t, time() - t
+
+
+def check_http(onion_addr, port_number, path, timeout):
+    """Check for Onion Service connectivity over HTTP using GET
+    """
+    path = path.lstrip('/')
+    url = "http://%s.onion:%d/%s" % (onion_addr, port_number, path)
+    return _check_url(url, timeout)
+
+
+def check_https(onion_addr, port_number, path, timeout):
+    """Check for Onion Service connectivity over HTTPS using GET
+    """
+    path = path.lstrip('/')
+    url = "https://%s.onion:%d/%s" % (onion_addr, port_number, path)
+    return _check_url(url, timeout)

--- a/onionbalance/manager.py
+++ b/onionbalance/manager.py
@@ -62,6 +62,14 @@ def parse_cmd_args():
     return parser
 
 
+def check_global_health():
+    """Run a health check across all instances under all services
+    """
+    for s in config.services:
+        s.check_health()
+    logger.debug("Health checks completed")
+
+
 def main():
     """
     Entry point when invoked over the command line.
@@ -115,7 +123,7 @@ def main():
         logger.debug("Successfully authenticated on the Tor control "
                      "connection.")
 
-    status_socket = status.StatusSocket(config.STATUS_SOCKET_LOCATION)
+    status_socket = status.StatusSocket(config)
     eventhandler.SignalHandler(controller, status_socket)
 
     # Disable no-member due to bug with "Instance of 'Enum' has no * member"
@@ -147,6 +155,7 @@ def main():
     scheduler.add_job(config.REFRESH_INTERVAL, fetch_instance_descriptors,
                       controller)
     scheduler.add_job(config.PUBLISH_CHECK_INTERVAL, publish_all_descriptors)
+    scheduler.add_job(config.HEALTH_CHECK_INTERVAL, check_global_health)
 
     # Run initial fetch of HS instance descriptors
     scheduler.run_all(delay_seconds=config.INITIAL_DELAY)

--- a/onionbalance/settings.py
+++ b/onionbalance/settings.py
@@ -47,6 +47,13 @@ def parse_config_file(config_file):
         if not os.path.isabs(service.get('key')):
             service['key'] = os.path.join(config_directory, service['key'])
 
+        service.setdefault('health_check', {})
+        # Do not run health checks by default
+        service['health_check'].setdefault('type', None)
+        service['health_check'].setdefault('port', 80)
+        service['health_check'].setdefault('path', '/')
+        service['health_check'].setdefault('timeout', 15)
+
     return config_data
 
 
@@ -106,7 +113,8 @@ def initialize_services(controller, services_config):
         config.services.append(onionbalance.service.Service(
             controller=controller,
             service_key=service_key,
-            instances=instances
+            instances=instances,
+            health_check_conf=service['health_check']
         ))
 
         # Store a global reference to current controller connection


### PR DESCRIPTION
Implement optional TCP, HTTP and HTTP2 health checking. Onion services are included or excluded from the published directory dynamically based on the health check output.