### PR TITLE
Fix exception when an out-of-date descriptor is received

### DIFF
--- a/onionbalance/eventhandler.py
+++ b/onionbalance/eventhandler.py
@@ -28,7 +28,12 @@ class EventHandler(object):
         if status_event.status_type == stem.StatusType.GENERAL:
             if status_event.action == "CONSENSUS_ARRIVED":
                 # Update the local view of the consensus in OnionBalance
-                consensus.refresh_consensus()
+                try:
+                    consensus.refresh_consensus()
+                except Exception:
+                    logger.exception("An unexpected exception occured in the "
+                                     "when processing the consensus update "
+                                     "callback.")
 
     @staticmethod
     def new_desc(desc_event):
@@ -59,7 +64,11 @@ class EventHandler(object):
             return None
 
         # Send content to callback function which will process the descriptor
-        descriptor.descriptor_received(descriptor_text)
+        try:
+            descriptor.descriptor_received(descriptor_text)
+        except Exception:
+            logger.exception("An unexpected exception occured in the "
+                             "new descriptor callback.")
 
         return None
 

--- a/onionbalance/instance.py
+++ b/onionbalance/instance.py
@@ -125,7 +125,7 @@ class Instance(object):
                          self.onion_address,
                          parsed_descriptor.published,
                          self.timestamp)
-            return
+            return False
         else:
             self.timestamp = parsed_descriptor.published
 


### PR DESCRIPTION
This commit fixes a bug where `None` was returned from `Instance.update_descriptor()` rather than a boolean. If a received instance descriptor is older than the current descriptor it was discarded and None was returned. 

Instead `False` should be returned as the boolean result it later compared in `descriptor_received()`.

Resolves exception in #62.